### PR TITLE
feat(minwindef): add extension traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@
     windows-sys = {version = "0.52", optional = true}
 
 [features]
-    default      = ["winrs"]
+    default      = ["winrs", "ext-impls"]
     no-minwindef = []
+    ext-impls    = []
     winrs        = ["dep:windows"]
     winsys       = ["dep:windows-sys"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,3 +38,12 @@ compile_error!(
 pub mod minwindef;
 #[cfg(feature = "no-minwindef")]
 pub(crate) mod minwindef;
+
+/// Wrapper for all extension traits this crate defines
+///
+/// All traits can be used with `use windows_ext::ext::*`.
+#[cfg(feature = "ext-impls")]
+pub mod ext {
+    #[cfg(not(feature = "no-minwindef"))]
+    pub use crate::minwindef::ext::*;
+}

--- a/src/minwindef/ext.rs
+++ b/src/minwindef/ext.rs
@@ -1,0 +1,121 @@
+//! This module provides extension traits that expose the freestanding functions
+//! from [minwindef][crate::minwindef] directly on the respective types.
+//!
+//! These traits can also be used with [new-types](https://doc.rust-lang.org/rust-by-example/generics/new_types.html).
+
+/// This trait provides the freestanding functions from [minwindef][crate::minwindef]
+/// directly on DWORDs ([u32]).
+///
+/// When using [new-types](https://doc.rust-lang.org/rust-by-example/generics/new_types.html) that wrap a DWORD,
+/// you can implement this trait by implementing the [value][DWordExt::value] method.
+///
+/// This trait is included in the convenience wrapper [`windows_ext::ext`][crate::ext].
+///
+/// ```
+/// use windows_ext::ext::DWordExt; // or: windows_ext::minwindef::ext::DWordExt;
+///
+/// assert_eq!(0x1234_5678u32.hiword(), 0x1234);
+/// assert_eq!(0x1234_5678u32.loword(), 0x5678);
+/// ```
+pub trait DWordExt: Copy {
+    /// Gets the value of the DWORD.
+    fn value(self) -> u32;
+
+    /// Get the low order word as [u16]
+    ///
+    /// ```
+    /// # use windows_ext::ext::DWordExt;
+    /// assert_eq!(0x1234_5678u32.loword(), 0x5678);
+    /// ```
+    #[inline(always)]
+    fn loword(self) -> u16 {
+        super::loword(self.value())
+    }
+
+    /// Get the high order word as [u16]
+    ///
+    /// ```
+    /// # use windows_ext::ext::DWordExt;
+    /// assert_eq!(0x1234_5678u32.hiword(), 0x1234);
+    /// ```
+    #[inline(always)]
+    fn hiword(self) -> u16 {
+        super::hiword(self.value())
+    }
+
+    /// Split a single dword into both of its words (lo, hi)
+    ///
+    /// ```
+    /// # use windows_ext::ext::DWordExt;
+    /// assert_eq!(0x1234_5678u32.split(), (0x5678, 0x1234));
+    /// ```
+    #[inline(always)]
+    fn split(self) -> (u16, u16) {
+        super::splitdword(self.value())
+    }
+}
+
+impl DWordExt for u32 {
+    #[inline(always)]
+    fn value(self) -> u32 {
+        self
+    }
+}
+
+/// This trait provides the freestanding functions from [minwindef][crate::minwindef]
+/// directly on QWORDs ([u64]).
+///
+/// When using [new-types](https://doc.rust-lang.org/rust-by-example/generics/new_types.html) that wrap a QWORD,
+/// you can implement this trait by implementing the [value][QWordExt::value] method.
+///
+/// This trait is included in the convenience wrapper [`windows_ext::ext`][crate::ext].
+///
+/// ```
+/// use windows_ext::ext::QWordExt; // or: windows_ext::minwindef::ext::DWordExt;
+///
+/// assert_eq!(0x1234_5678_9abc_def0u64.hidword(), 0x1234_5678);
+/// assert_eq!(0x1234_5678_9abc_def0u64.lodword(), 0x9abc_def0);
+/// ```
+pub trait QWordExt: Copy {
+    /// Gets the value of the QWORD.
+    fn value(self) -> u64;
+
+    /// Get the low order double word as [u32]
+    ///
+    /// ```
+    /// # use windows_ext::ext::QWordExt;
+    /// assert_eq!(0x1234_5678_9abc_def0u64.lodword(), 0x9abc_def0);
+    /// ```
+    #[inline(always)]
+    fn lodword(self) -> u32 {
+        super::lodword(self.value())
+    }
+
+    /// Get the high order double word as [u32]
+    ///
+    /// ```
+    /// # use windows_ext::ext::QWordExt;
+    /// assert_eq!(0x1234_5678_9abc_def0u64.hidword(), 0x1234_5678);
+    /// ```
+    #[inline(always)]
+    fn hidword(self) -> u32 {
+        super::hidword(self.value())
+    }
+
+    /// Split a single quad word into both of its double words (lo, hi)
+    ///
+    /// ```
+    /// # use windows_ext::ext::QWordExt;
+    /// assert_eq!(0x1234_5678_9abc_def0u64.split(), (0x9abc_def0, 0x1234_5678));
+    /// ```
+    #[inline(always)]
+    fn split(self) -> (u32, u32) {
+        super::splitqword(self.value())
+    }
+}
+
+impl QWordExt for u64 {
+    fn value(self) -> u64 {
+        self
+    }
+}

--- a/src/minwindef/mod.rs
+++ b/src/minwindef/mod.rs
@@ -24,6 +24,9 @@
 //! let (hi, lo) = splitdword(full)
 //! ```
 
+#[cfg(feature = "ext-impls")]
+pub mod ext;
+
 /// Get the low order word as u16
 #[inline(always)]
 pub const fn loword(dw: u32) -> u16 {


### PR DESCRIPTION
Adds the `QWordExt` and `QWordExt` traits, which wrap the freestanding functions in `minwindef`.
These are convenience wrappers, so one can write `0x1234_5678u32.loword()`.

---

**Off-Topic**

Some initial thoughts:

- GitHub CI would be great (also testing the minimum supported rust version and combinations of features [e.g. through a `matrix`])
	- Maybe dependabot updates
	- Maybe automatic releases (through tags) - see for example https://github.com/crate-ci/cargo-release
- Documentation that's automatically built should be provided (e.g. on GitHub pages)
	- _While testing, I noticed that `<version>` should be `&lt;version&gt;` at the top of `minwindef`'s module docs_
	- Some examples for the functions would be cool (like in the `std` docs)
- An example of how to use this repo as a git dependency, so people don't have to search up on the syntax
- Maybe the `minwindef` module docs could show a mapping of the types (`DWORD -> u32` and so on)
- Having a double-negative to check for `minwindef` seems weird. I think it's better to have a `minwindef` feature that's enabled by default is easier.

I want to add more functions (and `-Ext`s) for W/LPARAM, or, more generally, for pointer-sized types.